### PR TITLE
Fix #755 error: Orders always show created time as two minutes past t…

### DIFF
--- a/packages/reaction-core/client/templates/dashboard/orders/orders.html
+++ b/packages/reaction-core/client/templates/dashboard/orders/orders.html
@@ -69,7 +69,7 @@
 
 <template name="orderStatusDetail">
   <div class="col-xs-8">
-    <div data-i18n="orderDetail.created">Created {{orderAge}} {{dateFormat createdAt format="MMM D, YYYY HH:MM"}}</div>
+    <div data-i18n="orderDetail.created">Created {{orderAge}} {{dateFormat createdAt format="MMM D, YYYY hh:mm:ss A"}}</div>
     {{#if shipmentTracking}}
     <p>Tracking: <a href="#">{{shipmentTracking}}</a></p>
     {{/if}}


### PR DESCRIPTION
Fix the typo in the format of dateFormat in orders.html. Changed MM (month) to mm (minutes). Tested.